### PR TITLE
SEO: metadata, structured data, crawl files; fix CLS and a canonical leak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# macOS
+.DS_Store
+
+# JetBrains IDE
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# מנורת המאור — menorat-hamaor.co.il
+
+Static site for the annotated edition of **מנורת המאור** by Rabbi Yitzchak Aboab,
+vocalized in Yemenite pointing and explained by **ציון טל (בוטא)**.
+
+Served by **GitHub Pages** from `master` at <https://menorat-hamaor.co.il/>
+(domain via the `CNAME` file). There is no build step — `index.html` is served
+as-is, so anything committed here goes live.
+
+## Layout
+
+| Path | Purpose |
+| --- | --- |
+| `index.html` | The entire site: one Hebrew RTL page, inline CSS |
+| `style.css` | Legacy stylesheet, largely superseded by the inline styles |
+| `images/1–3.png` | Book cover / sample pages shown in the slick carousel |
+| `demo/*.pdf` | Sample chapters and rabbinic approbations (הסכמות) |
+| `favicon.svg` | Menorah favicon (also used as the apple-touch-icon) |
+| `robots.txt`, `sitemap.xml` | Crawl directives; sitemap lists the page + all PDFs |
+| `CNAME` | Custom domain for GitHub Pages |
+| `google256c1f51882b8dbb.html` | Google Search Console verification |
+
+### Superseded drafts — do not link to these
+
+`index-10-12-2023.html`, `index-16-11-2023.html` and `gpt-index2.html` are older
+drafts kept for reference. They each carry `<meta name="robots" content="noindex,
+nofollow">` and a canonical pointing at the home page, and are deliberately left
+crawlable so the `noindex` is actually seen and honoured — blocking them in
+`robots.txt` instead would leave any already-indexed copies stuck in the index.
+
+An earlier version of this site was a Flask + AngularJS application. It is no
+longer deployed and has been retired; this static page replaced it.
+
+## Editing notes
+
+Two things in `index.html` are load-bearing and easy to break:
+
+- The document is `dir="rtl"` for the Hebrew content, but **`.carousel` is pinned
+  to `direction: ltr`**. The slick carousel positions its track with LTR
+  float/translate maths; letting it inherit RTL pushes every slide off-screen and
+  the cover silently disappears.
+- **`.carousel` has a fixed `height: 400px`.** Before slick initialises, the three
+  400px images stack vertically (~1200px) and then collapse to a single 400px row.
+  Reserving the height keeps Cumulative Layout Shift at 0 instead of 0.27.
+
+The jQuery and slick assets are pinned with Subresource Integrity hashes. If you
+bump a version you must recompute the hash, or the browser will silently refuse to
+load the file and the carousel will stop working:
+
+```sh
+curl -sS <url> | openssl dgst -sha384 -binary | openssl base64 -A
+```
+
+## Local preview
+
+```sh
+python3 -m http.server 8000   # then open http://localhost:8000/
+```

--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img"
+     aria-label="מנורת המאור">
+  <title>מנורת המאור</title>
+  <rect width="64" height="64" rx="10" fill="#5b2b17"/>
+  <g fill="none" stroke="#f0c04a" stroke-width="4"
+     stroke-linecap="round" stroke-linejoin="round">
+    <!-- central stem -->
+    <path d="M32 22v24"/>
+    <!-- three arched branches on each side -->
+    <path d="M32 34c0-8-4-12-9-12s-9 4-9 12"/>
+    <path d="M32 34c0-8 4-12 9-12s9 4 9 12"/>
+    <path d="M32 30c0-6-3-9-6.5-9"/>
+    <path d="M32 30c0 -6 3-9 6.5-9"/>
+    <!-- base -->
+    <path d="M23 50h18"/>
+    <path d="M32 46v4"/>
+  </g>
+  <!-- seven flames -->
+  <g fill="#ffe9a8">
+    <circle cx="14" cy="19" r="2.6"/>
+    <circle cx="25.5" cy="18" r="2.6"/>
+    <circle cx="32" cy="16" r="3"/>
+    <circle cx="38.5" cy="18" r="2.6"/>
+    <circle cx="50" cy="19" r="2.6"/>
+  </g>
+</svg>

--- a/gpt-index2.html
+++ b/gpt-index2.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Scratch landing-page experiment. Kept for reference only - must not be indexed. -->
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="canonical" href="https://menorat-hamaor.co.il/">
   <title>עמוד נחיתה</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css">
   <style>

--- a/index-10-12-2023.html
+++ b/index-10-12-2023.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Superseded draft of the home page. Kept for reference only - must not be indexed. -->
+  <meta name="robots" content="noindex, nofollow">
+  <link rel="canonical" href="https://menorat-hamaor.co.il/">
   <title>מנורת המאור / ציון טל (בוטא)</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css">
   <style>

--- a/index-16-11-2023.html
+++ b/index-16-11-2023.html
@@ -9,8 +9,11 @@
     <title>מנורת המאור|ספר מנורת המאור ציון טל (בוטא) שליט"א|מנורת המאור ספר</title>
 
 
-    <link rel='canonical'
-          href='https://www.sefer.org.il/items/3730251-%D7%9E%D7%A9%D7%A0%D7%AA-%D7%94%D7%92%D7%9C%D7%92%D7%95%D7%9C%D7%99%D7%9D-%D7%94%D7%A8%D7%91-%D7%91%D7%95%D7%A2%D7%96-%D7%A9%D7%9C%D7%95%D7%9D-%D7%A9%D7%9C%D7%99%D7%98-%D7%90-%D7%A1%D7%A4%D7%A8-%D7%97%D7%93%D7%A9-%D7%94%D7%95%D7%A6%D7%90%D7%94-%D7%9C%D7%90%D7%95%D7%A8-%D7%99%D7%A4%D7%94-%D7%A0%D7%95%D7%A3'/>
+    <!-- Superseded draft of the home page. Kept for reference only - must not be indexed.
+         The previous canonical here pointed at an unrelated third-party bookshop page
+         (a leftover from the saved-page template) and has been corrected. -->
+    <meta name="robots" content="noindex, nofollow">
+    <link rel='canonical' href='https://menorat-hamaor.co.il/'/>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <!-- css -->
     <link rel="stylesheet" type="text/css"

--- a/index.html
+++ b/index.html
@@ -1,13 +1,44 @@
 <!DOCTYPE html>
-<html lang="he">
+<html lang="he" dir="rtl">
 
 <!--edit with: https://onlinehtmleditor.dev/-->
 
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>מנורת המאור / ציון טל (בוטא)</title>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css">
+
+  <title>מנורת המאור מפורש ומבואר בניקוד תימני | ציון טל (בוטא)</title>
+  <meta name="description"
+        content="ספר מנורת המאור לרבנו יצחק אבוהב – מנוקד בניקוד תימני ומבואר בעברית בת ימינו מאת ציון טל (בוטא). כ-120 פרקים לפי פרשות השבוע והמועדים, קטעים לטעימה והסכמות.">
+  <link rel="canonical" href="https://menorat-hamaor.co.il/">
+  <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
+  <meta name="author" content="ציון טל (בוטא)">
+  <meta name="theme-color" content="#4CAF50">
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="apple-touch-icon" href="/favicon.svg">
+
+  <!-- Open Graph / social sharing -->
+  <meta property="og:type" content="book">
+  <meta property="og:locale" content="he_IL">
+  <meta property="og:site_name" content="מנורת המאור / ציון טל (בוטא)">
+  <meta property="og:title" content="מנורת המאור מפורש ומבואר בניקוד תימני | ציון טל (בוטא)">
+  <meta property="og:description"
+        content="ספר מנורת המאור לרבנו יצחק אבוהב הספרדי – מנוקד בניקוד תימני, מפורש ומבואר בעברית בת ימינו מאת ציון טל (בוטא). כ-120 פרקים לפי פרשות השבוע והמועדים.">
+  <meta property="og:url" content="https://menorat-hamaor.co.il/">
+  <meta property="og:image" content="https://menorat-hamaor.co.il/images/1.png">
+  <meta property="og:image:width" content="346">
+  <meta property="og:image:height" content="479">
+  <meta property="og:image:alt" content="כריכת הספר מנורת המאור מפורש ומבואר">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="מנורת המאור מפורש ומבואר בניקוד תימני | ציון טל (בוטא)">
+  <meta name="twitter:description"
+        content="ספר מנורת המאור לרבנו יצחק אבוהב הספרדי – מנוקד בניקוד תימני, מפורש ומבואר בעברית בת ימינו מאת ציון טל (בוטא).">
+  <meta name="twitter:image" content="https://menorat-hamaor.co.il/images/1.png">
+
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.css"
+        integrity="sha384-ZwVa1S/NX6dEzJaHv2OILVrnj7ERqTH6pd/ubsDTHTrgAEz2kUufO/KLo6frtnOB"
+        crossorigin="anonymous" referrerpolicy="no-referrer">
   <style>
     body {
       text-align: center;
@@ -27,9 +58,21 @@
     }
     .carousel {
       margin-top: 40px;
+      /* The document is dir="rtl" for the Hebrew content, but slick positions its
+         track with LTR float/translate math - inheriting RTL pushes every slide
+         off-screen. Keep this subtree LTR. */
+      direction: ltr;
+      /* Reserve the final one-slide height up front. Until slick initialises the
+         three 400px images stack vertically (~1200px) and then collapse to a
+         single 400px row, shifting the whole page up - that was most of the
+         Cumulative Layout Shift. */
+      height: 400px;
+      overflow: hidden;
     }
     .carousel img {
       height: 400px;
+      width: auto;
+      max-width: 100%;
       /*object-fit: cover;*/
     }
     .btn {
@@ -53,18 +96,108 @@
         margin: auto;
     }
   </style>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": "https://menorat-hamaor.co.il/#website",
+        "url": "https://menorat-hamaor.co.il/",
+        "name": "מנורת המאור / ציון טל (בוטא)",
+        "description": "ספר מנורת המאור לרבנו יצחק אבוהב הספרדי, מנוקד בניקוד תימני ומבואר בעברית בת ימינו",
+        "inLanguage": "he"
+      },
+      {
+        "@type": "Book",
+        "@id": "https://menorat-hamaor.co.il/#book",
+        "name": "מנורת המאור מפורש ומבואר",
+        "alternateName": "מנורת המאור",
+        "url": "https://menorat-hamaor.co.il/",
+        "image": "https://menorat-hamaor.co.il/images/1.png",
+        "inLanguage": "he",
+        "bookFormat": "https://schema.org/Hardcover",
+        "genre": ["ספרי מוסר", "אגדות חז\"ל", "יהדות תימן"],
+        "about": "אגדות חז\"ל ומוסר על פי מנורת המאור, מסודר לפי פרשות השבוע והמועדים",
+        "description": "ספר מנורת המאור לרבנו יצחק אבוהב הספרדי, מנוקד ומוגה בניקוד תימני, מפורש ומבואר עם סימני שאלה ותמיהה. כ-120 פרקים מובחרים בהתאם לפרשות השבוע, המועדים ואירועים בחיי האדם, מתוך כ-340 פרקי הספר.",
+        "author": {
+          "@type": "Person",
+          "name": "רבנו יצחק אבוהב הספרדי",
+          "description": "מחבר ספר מנורת המאור, חי במאות השלוש עשרה והארבע עשרה בספרד"
+        },
+        "editor": {
+          "@id": "https://menorat-hamaor.co.il/#editor"
+        },
+        "contributor": {
+          "@id": "https://menorat-hamaor.co.il/#editor"
+        },
+        "publisher": {
+          "@id": "https://menorat-hamaor.co.il/#publisher"
+        },
+        "workExample": [
+          {
+            "@type": "Book",
+            "name": "מנורת המאור – פרשת בראשית (קטע לטעימה)",
+            "url": "https://menorat-hamaor.co.il/demo/bereshit.pdf",
+            "inLanguage": "he",
+            "encodingFormat": "application/pdf"
+          },
+          {
+            "@type": "Book",
+            "name": "מנורת המאור – פרשת משפטים (קטע לטעימה)",
+            "url": "https://menorat-hamaor.co.il/demo/mishpatim.pdf",
+            "inLanguage": "he",
+            "encodingFormat": "application/pdf"
+          },
+          {
+            "@type": "Book",
+            "name": "מנורת המאור – פרשת ויקרא (קטע לטעימה)",
+            "url": "https://menorat-hamaor.co.il/demo/vayikra.pdf",
+            "inLanguage": "he",
+            "encodingFormat": "application/pdf"
+          }
+        ]
+      },
+      {
+        "@type": "Person",
+        "@id": "https://menorat-hamaor.co.il/#editor",
+        "name": "ציון טל (בוטא)",
+        "alternateName": "טל ציון",
+        "description": "כתב וערך את הביאור לספר מנורת המאור. נולד במגדיאל בשנת תש\"י, יועץ מס בהוד השרון, כתב את חיבורו בין השנים תש\"ס–תש\"ע.",
+        "birthPlace": "מגדיאל",
+        "jobTitle": "יועץ מס",
+        "knowsAbout": ["מנורת המאור", "ניקוד תימני", "אגדות חז\"ל", "מסורת הקריאה של יהודי תימן"]
+      },
+      {
+        "@type": "Organization",
+        "@id": "https://menorat-hamaor.co.il/#publisher",
+        "name": "מו\"ל – טל ציון",
+        "url": "https://menorat-hamaor.co.il/",
+        "telephone": ["+972-9-7401112", "+972-54-7334550"],
+        "address": {
+          "@type": "PostalAddress",
+          "streetAddress": "רחוב נטעים 35",
+          "addressLocality": "הוד השרון",
+          "addressCountry": "IL"
+        }
+      }
+    ]
+  }
+  </script>
 </head>
 
 <body>
+<main>
   <div class="container">
     <h1>
         מנורת המאור / ציון טל (בוטא)
     </h1>
 
     <div class="carousel">
-      <img src="images/1.png" style="" alt="תמונה 1">
-      <img src="images/2.png" style=""  alt="תמונה 2">
-      <img src="images/3.png" style=""  alt="תמונה 3">
+      <img src="images/1.png" width="346" height="479" alt="כריכת הספר מנורת המאור מפורש ומבואר בניקוד תימני, מאת ציון טל (בוטא)">
+      <img src="images/2.png" width="377" height="422" alt="שער הספר מנורת המאור לרבנו יצחק אבוהב הספרדי">
+      <img src="images/3.png" width="612" height="408" loading="lazy" alt="עמוד לדוגמה מתוך ספר מנורת המאור המנוקד והמבואר">
     </div>
 
 
@@ -78,7 +211,7 @@
 
   <p style="text-align:justify"><span style="font-size:12pt"><span style="font-family:&quot;Times New Roman&quot;,serif"><span style="font-size:24.0pt"><span style="font-family:&quot;David&quot;,sans-serif">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ספר</span></span></span></span></p>
 
-<h1 style="margin-right:-27px; text-align:justify"><span style="font-size:60pt"><span style="font-family:&quot;Times New Roman&quot;,serif"><span style="font-size:42.0pt"><span style="font-family:&quot;David&quot;,sans-serif">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; מנורת המאור</span></span></span></span></h1>
+<h2 style="margin-right:-27px; text-align:justify"><span style="font-size:60pt"><span style="font-family:&quot;Times New Roman&quot;,serif"><span style="font-size:42.0pt"><span style="font-family:&quot;David&quot;,sans-serif">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; מנורת המאור</span></span></span></span></h2>
 
 <p style="text-align:justify">&nbsp;</p>
 
@@ -240,22 +373,31 @@
 
 
 
-    <div><h3>לעיון וטעימה של קטעים מפרקי הספר </h3></div>
-    <a href="demo/bereshit.pdf" target="_blank" title="פרשת בראשית">פרשת בראשית</a><span> | </span>
-    <a href="demo/mishpatim.pdf" target="_blank" title="פרשת משפטים">פרשת משפטים</a><span> | </span>
-    <a href="demo/vayikra.pdf" target="_blank" title="פרשת ויקרא">פרשת ויקרא</a><span>
+    <div dir="rtl">
+      <h2>לעיון וטעימה של קטעים מפרקי הספר</h2>
+      <p>
+        <a href="demo/bereshit.pdf" target="_blank" rel="noopener" title="מנורת המאור מבואר – פרשת בראשית (PDF)">פרשת בראשית</a><span> | </span>
+        <a href="demo/mishpatim.pdf" target="_blank" rel="noopener" title="מנורת המאור מבואר – פרשת משפטים (PDF)">פרשת משפטים</a><span> | </span>
+        <a href="demo/vayikra.pdf" target="_blank" rel="noopener" title="מנורת המאור מבואר – פרשת ויקרא (PDF)">פרשת ויקרא</a>
+      </p>
 
+      <h2>לצפייה בהסכמות לספר</h2>
+      <p>
+        <a href="demo/haskamot-razabi.pdf" target="_blank" rel="noopener" title="הסכמת הרב יצחק רצאבי לספר מנורת המאור (PDF)">הסכמת הרב רצאבי</a><span> | </span>
+        <a href="demo/haskamot-mahpud.pdf" target="_blank" rel="noopener" title="הסכמת הרב מחפוד לספר מנורת המאור (PDF)">הסכמת הרב מחפוד</a><span> | </span>
+        <a href="demo/haskamot-basis.pdf" target="_blank" rel="noopener" title="הסכמת הרב בסיס לספר מנורת המאור (PDF)">הסכמת הרב בסיס</a><span> | </span>
+        <a href="demo/haskamot-gamliel.pdf" target="_blank" rel="noopener" title="הסכמת הרב גמליאל לספר מנורת המאור (PDF)">הסכמת הרב גמליאל</a><span> | </span>
+        <a href="demo/haskamot-arusi.pdf" target="_blank" rel="noopener" title="הסכמת הרב ערוסי לספר מנורת המאור (PDF)">הסכמת הרב ערוסי</a>
+      </p>
+    </div>
+</main>
 
-    <div><h3>לצפייה בהסכמות לספר</h3></div>
-    <a href="demo/haskamot-razabi.pdf" target="_blank" title="הסכמת הרב רצאבי">הסכמת הרב רצאבי</a><span> | </span>
-    <a href="demo/haskamot-mahpud.pdf" target="_blank" title="הסכמת הרב מחפוד">הסכמת הרב מחפוד</a><span> | </span>
-    <a href="demo/haskamot-basis.pdf" target="_blank" title="הסכמת הרב בסיס">הסכמת הרב בסיס</a><span> | </span>
-    <a href="demo/haskamot-gamliel.pdf" target="_blank" title="הסכמת הרב גמליאל">הסכמת הרב גמליאל</a><span> | </span>
-    <a href="demo/haskamot-arusi.pdf" target="_blank" title="הסכמת הרב ערוסי">הסכמת הרב ערוסי</a><span> | </span>
-
-
-  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"></script>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"
+          integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK"
+          crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.8.1/slick.min.js"
+          integrity="sha384-YGnnOBKslPJVs35GG0TtAZ4uO7BHpHlqJhs0XK3k6cuVb6EBtl+8xcvIIOKV5wB+"
+          crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>
     $(document).ready(function() {
       $('.carousel').slick({

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,11 @@
+User-agent: *
+Allow: /
+
+# Old drafts of the home page carry <meta name="robots" content="noindex">.
+# They are deliberately left crawlable so that the noindex is actually seen and
+# honoured - blocking them here instead would leave any stale copies indexed.
+
+# Internal working document, not for search results
+Disallow: /demo/*.doc$
+
+Sitemap: https://menorat-hamaor.co.il/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <url>
+    <loc>https://menorat-hamaor.co.il/</loc>
+    <lastmod>2026-07-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <!-- Sample chapters -->
+  <url>
+    <loc>https://menorat-hamaor.co.il/demo/bereshit.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://menorat-hamaor.co.il/demo/mishpatim.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://menorat-hamaor.co.il/demo/vayikra.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- Rabbinic approbations -->
+  <url>
+    <loc>https://menorat-hamaor.co.il/demo/haskamot-razabi.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://menorat-hamaor.co.il/demo/haskamot-mahpud.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://menorat-hamaor.co.il/demo/haskamot-basis.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://menorat-hamaor.co.il/demo/haskamot-gamliel.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://menorat-hamaor.co.il/demo/haskamot-arusi.pdf</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+</urlset>


### PR DESCRIPTION
## Summary

The live page had **no** meta description, canonical, social tags or structured data, and both `/robots.txt` and `/sitemap.xml` returned 404. This adds them, fixes a failing Core Web Vital, and closes a canonical leak that was attributing this domain's content to a third-party shop.

Measured with Lighthouse (mobile), live site vs. this branch:

| | Before | After |
|---|---|---|
| SEO | 91 | **100** |
| Accessibility | 96 | **100** |
| **CLS** | **0.266** (failing) | **0** |

## Discoverability

- Meta description, canonical, Open Graph + Twitter cards, `theme-color`, menorah favicon (SVG).
- `robots.txt` and `sitemap.xml` (9 URLs — the page plus every PDF; each verified to resolve).
- **JSON-LD `@graph`**: `Book` (Aboab as author, ציון טל as editor, the three sample chapters as `workExample`), `Person`, `Organization` with the publisher's address and phone numbers, and `WebSite`.
- Retitled to lead with the primary keyword plus the differentiators people actually search for — `מנורת המאור מפורש ומבואר בניקוד תימני`.

## Structure

Two competing `<h1>`s collapsed to one, PDF section headings promoted to `<h2>` for a sequential outline, placeholder alt text (`תמונה 1`) replaced with descriptive Hebrew, `dir="rtl"` moved to `<html>`, content wrapped in `<main>`, `rel="noopener"` on every `target="_blank"`, and a stray unclosed `<span>` closed.

## CLS 0.266 → 0

Images now declare `width`/`height` so the aspect ratio is known before download. The bigger cause: until slick initialises, the three 400px images stack vertically (~1200px) and then collapse to a single 400px row, jerking the page up ~800px. `.carousel` now reserves that height.

## Two things worth a close look

**A canonical was leaking off-domain.** `index-16-11-2023.html` is a 773 KB scraped copy of a *sefer.org.il* bookshop page, live on this domain, whose `<link rel="canonical">` still pointed at **that shop's product page for a different book** — telling Google this domain's content belongs to them — plus 329 outbound links there. Canonical repointed here and `noindex, nofollow` set. I verified in-browser that the parser picks the tag up, since that file's markup is malformed and a text grep isn't trustworthy.

**A duplicate was competing for the same query.** `index-10-12-2023.html` was live with a byte-identical `<title>` to the home page. `gpt-index2.html` was a scratch landing page. Both now `noindex, nofollow` with a canonical.

All three are **deliberately left crawlable** in `robots.txt`: a `Disallow` would prevent Google from ever seeing the `noindex`, leaving already-indexed copies stuck in the index. Once they drop out, they can be blocked or deleted.

## Carousel regression, caught and fixed

Moving `dir="rtl"` to `<html>` **broke the carousel** — slick positions its track with LTR float/translate maths, so every slide translated off-screen and the cover silently vanished. Found it by screenshotting against the live site rather than trusting the DOM, which misleadingly reported the image as visible at `opacity: 1`. Fixed by pinning `.carousel` to `direction: ltr`.

Verified after the fix: carousel renders identically to production on desktop and mobile, console clean, no 404s.

## Note on the pinned assets

jQuery and slick are now pinned with Subresource Integrity. Hashes were computed from the live CDN files, and jQuery's `sha256` was cross-checked against the published value before being trusted — a wrong hash silently blocks the script and kills the carousel. **Bumping either version requires recomputing the hash** (documented in the new README).

## Not addressed

The covers are stretched to 600×400 from small sources (346×479, 377×422) — the only remaining Lighthouse failure. This is pre-existing and identical on the live site. Fixing it properly needs higher-resolution images; `object-fit: contain` would letterbox them instead and change the look, so I left it alone.

## Verification

- Lighthouse mobile before/after as tabled above.
- Rendered on desktop (1280×800) and mobile — matches production.
- JSON-LD parses; sitemap is valid XML and every URL resolves.
- No console errors, no failed requests.
- `.gitignore` added; no `.idea/` or `.DS_Store` in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)