### PR TITLE
Stop the carousel distorting the book covers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,21 @@ clean console proves nothing here.
    against the live site, never from computed styles.**
 
 2. **`.carousel` must keep its fixed `height: 400px`.** Until slick initialises the
-   three 400px images stack vertically (~1200px) and then collapse to one 400px
-   row, shifting the page up ~800px. That was 0.266 of Cumulative Layout Shift;
-   reserving the height makes it 0.
+   three images stack vertically and then collapse to one 400px row, shifting the
+   page up ~800px. That was 0.266 of Cumulative Layout Shift; reserving the height
+   makes it 0.
+
+3. **Every slide must stay a wrapper `<div class="slide">`, never a bare `<img>`.**
+   Slick writes the slide width as an *inline style* onto whatever the direct
+   children of `.carousel` are. With bare `<img>` children it set
+   `style="width: 600px"` on each image, stretching all three covers to the slide
+   width and distorting the two portrait ones. The wrapper takes that inline width
+   instead, leaving the image free to keep its own proportions.
+
+   Relatedly, size the image with `max-height`/`max-width`, not a fixed `height`.
+   A fixed `height: 400px` plus `max-width: 100%` squashes the landscape cover as
+   soon as the viewport is narrower than the image — it passed on desktop and
+   failed only at mobile widths, so check both.
 
 ## jQuery and slick are pinned with SRI
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,13 @@ Two things in `index.html` are load-bearing and easy to break:
   float/translate maths; letting it inherit RTL pushes every slide off-screen and
   the cover silently disappears.
 - **`.carousel` has a fixed `height: 400px`.** Before slick initialises, the three
-  400px images stack vertically (~1200px) and then collapse to a single 400px row.
-  Reserving the height keeps Cumulative Layout Shift at 0 instead of 0.27.
+  images stack vertically and then collapse to a single 400px row. Reserving the
+  height keeps Cumulative Layout Shift at 0 instead of 0.27.
+- **Each slide is a wrapper `<div class="slide">`, not a bare `<img>`.** Slick writes
+  the slide width as an inline style onto the direct children of `.carousel`; with
+  bare images it stretched every cover to 600px and distorted the portrait ones.
+  Images are sized with `max-height`/`max-width` so they keep their proportions at
+  any viewport width.
 
 The jQuery and slick assets are pinned with Subresource Integrity hashes. If you
 bump a version you must recompute the hash, or the browser will silently refuse to

--- a/index.html
+++ b/index.html
@@ -69,10 +69,23 @@
       height: 400px;
       overflow: hidden;
     }
-    .carousel img {
+    /* Centre each cover in its slide, vertically too, since a landscape image is
+       shorter than the reserved 400px box on narrow screens. */
+    .carousel .slide {
+      display: flex !important;
+      align-items: center;
+      justify-content: center;
       height: 400px;
-      width: auto;
+    }
+
+    .carousel img {
+      /* Bound the image on both axes and let it scale, so it keeps its own
+         proportions at every viewport width. A fixed height with max-width:100%
+         squashes landscape covers once the container is narrower than the image. */
+      max-height: 400px;
       max-width: 100%;
+      width: auto;
+      height: auto;
       /*object-fit: cover;*/
     }
     .btn {
@@ -194,10 +207,13 @@
         מנורת המאור / ציון טל (בוטא)
     </h1>
 
+    <!-- Each slide is the wrapper div, not the <img>. Slick writes the slide width
+         inline onto whatever the direct children are; with bare <img> children it
+         stretched every cover to the full 600px slide width and distorted them. -->
     <div class="carousel">
-      <img src="images/1.png" width="346" height="479" alt="כריכת הספר מנורת המאור מפורש ומבואר בניקוד תימני, מאת ציון טל (בוטא)">
-      <img src="images/2.png" width="377" height="422" alt="שער הספר מנורת המאור לרבנו יצחק אבוהב הספרדי">
-      <img src="images/3.png" width="612" height="408" loading="lazy" alt="עמוד לדוגמה מתוך ספר מנורת המאור המנוקד והמבואר">
+      <div class="slide"><img src="images/1.png" width="346" height="479" alt="כריכת הספר מנורת המאור מפורש ומבואר בניקוד תימני, מאת ציון טל (בוטא)"></div>
+      <div class="slide"><img src="images/2.png" width="377" height="422" alt="שער הספר מנורת המאור לרבנו יצחק אבוהב הספרדי"></div>
+      <div class="slide"><img src="images/3.png" width="612" height="408" loading="lazy" alt="עמוד לדוגמה מתוך ספר מנורת המאור המנוקד והמבואר"></div>
     </div>
 
 


### PR DESCRIPTION
Fixes the last two Lighthouse failures I'd flagged as "needs higher-resolution images" — that diagnosis was wrong. No new images were needed.

**Lighthouse mobile is now 100 across all four categories, 0 failures**, with CLS still 0.

| | Before | After |
|---|---|---|
| Performance / Best Practices | 92 | **100** |
| SEO | 100 | 100 |
| Accessibility | 100 | 100 |
| CLS | 0 | 0 |

## The actual cause

All three covers rendered `600x400` regardless of their real proportions, so the two portrait ones (346×479, 377×422) were visibly stretched wide.

It wasn't a stylesheet at all — which is why the CSS looked correct and I initially misread it as a source-resolution problem. **Slick treats each direct child of `.carousel` as a slide and writes the slide width as an inline style onto it.** The children were the `<img>` elements themselves, so each got `style="width: 600px"`:

```
inlineStyleAttr: "width: 600px;"   ← from slick's JS, not any CSS rule
matchedWidthRules: [".carousel img { width: auto }"]
```

Overriding with `width: auto !important` *would* beat the inline style, but it breaks slick — its translate maths assumes every slide is `slideWidth` wide, so the slides would misalign.

## The fix

Wrap each image in `<div class="slide">`. The wrapper becomes the slide and takes the inline width; the image inside is free to keep its own aspect ratio.

Size images with `max-height`/`max-width` instead of a fixed `height`. This part matters: a fixed `height: 400px` with `max-width: 100%` **still** squashed the landscape cover once the container was narrower than the image — correct at 1280px but distorted at Lighthouse's 316px mobile width. Worth checking both widths, since the desktop view looks fine either way.

The slide is a centring flex box, so the shorter landscape image sits centred in the reserved 400px rather than pinned to the top.

## Verified

- Aspect preserved and **nothing upscaled** at both 1137px and 316px container widths (each image now renders at or below its natural size, so `image-size-responsive` passes too).
- Slides still advance; slick's slide width still `600px`; `.carousel` still reserves `400px` so CLS stays 0.
- Rendered on desktop (1280×800) and mobile (390×780) — covers upright and centred.

Notes added to `CLAUDE.md` and `README.md`, since the wrapper-div requirement is another rule that fails silently: remove the wrapper and slick will quietly stretch the covers again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)